### PR TITLE
Use X-Original-URI instead of X-Forwarded-Path

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ You can also use wildcards at the beginning and the end of host name, like `*.ba
 
 You can have multiple containers proxied by the same `VIRTUAL_HOST` by adding a `VIRTUAL_PATH` environment variable containing the absolute path to where the container should be mounted. For example with `VIRTUAL_HOST=foo.example.com` and `VIRTUAL_PATH=/api/v2/service`, then requests to http://foo.example.com/api/v2/service will be routed to the container. If you wish to have a container serve the root while other containers serve other paths, make give the root container a `VIRTUAL_PATH` of `/`.  Unmatched paths will be served by the container at `/` or will return the default nginx error page if no container has been assigned `/`.
 
-The full request URI will be forwarded to the serving container in the `X-Forwarded-Path` header.
+The full request URI will be forwarded to the serving container in the `X-Original-URI` header.
 
 ### Multiple Networks
 

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -132,7 +132,7 @@ proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
 proxy_set_header X-Forwarded-Ssl $proxy_x_forwarded_ssl;
 proxy_set_header X-Forwarded-Port $proxy_x_forwarded_port;
-proxy_set_header X-Forwarded-Path $request_uri;
+proxy_set_header X-Original-URI $request_uri;
 
 # Mitigate httpoxy attack (see README for details)
 proxy_set_header Proxy "";


### PR DESCRIPTION
If an application is supposed to run behind nginx-proxy (maybe for development) and ingress-nginx (Kubernetes for production) two different headers need to be checked.
Ingress uses "X-Original-URI" for that and it makes more sense as it contains the full URI as far as I can see.

That's why I propose to change X-Forwarded-Path to X-Original-URI aswell to be able to use both solutions.
See:
https://github.com/kubernetes/ingress-nginx/blob/master/rootfs/etc/nginx/template/nginx.tmpl#L803